### PR TITLE
build: remove pr stages

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -11,9 +11,6 @@ export default $config({
         ) {
           return { stage: "production" };
         }
-        if (event.type === "pull_request") {
-          return { stage: `pr-${event.number}` };
-        }
       },
     },
   },


### PR DESCRIPTION
stop deploying on every pr and instead introduce a staging environment that can selectively be used when necessary.