### PR TITLE
ignore sst-env files when formatting commits

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,6 @@
-pnpm-lock.yaml
+.husky
+.github
+.vscode
+node_modules
 sst-env.d.ts
+pnpm-lock.yaml

--- a/apps/nextjs/.prettierignore
+++ b/apps/nextjs/.prettierignore
@@ -1,0 +1,1 @@
+sst-env.d.ts

--- a/apps/nextjs/sst-env.d.ts
+++ b/apps/nextjs/sst-env.d.ts
@@ -2,58 +2,46 @@
 /* tslint:disable */
 /* eslint-disable */
 /* deno-fmt-ignore-file */
-import "sst";
-export {};
+import "sst"
+export {}
 declare module "sst" {
   export interface Resource {
-    Bucket1: {
-      name: string;
-      type: "sst.aws.Bucket";
-    };
-    Email1: {
-      configSet: string;
-      sender: string;
-      type: "sst.aws.Email";
-    };
-    MigrationLambda: {
-      name: string;
-      type: "sst.aws.Function";
-    };
-    MyRouter: {
-      type: "sst.aws.Router";
-      url: string;
-    };
-    MyWeb: {
-      type: "sst.aws.Nextjs";
-      url: string;
-    };
-    Postgres: {
-      database: string;
-      host: string;
-      password: string;
-      port: number;
-      type: "sst.aws.Postgres";
-      username: string;
-    };
-    Postgres1: {
-      database: string;
-      host: string;
-      password: string;
-      port: number;
-      type: "sst.aws.Postgres";
-      username: string;
-    };
-    SeedLambda: {
-      name: string;
-      type: "sst.aws.Function";
-    };
-    Vpc: {
-      bastion: string;
-      type: "sst.aws.Vpc";
-    };
-    Vpc1: {
-      bastion: string;
-      type: "sst.aws.Vpc";
-    };
+    "Bucket1": {
+      "name": string
+      "type": "sst.aws.Bucket"
+    }
+    "Email1": {
+      "configSet": string
+      "sender": string
+      "type": "sst.aws.Email"
+    }
+    "MigrationLambda": {
+      "name": string
+      "type": "sst.aws.Function"
+    }
+    "MyRouter": {
+      "type": "sst.aws.Router"
+      "url": string
+    }
+    "MyWeb": {
+      "type": "sst.aws.Nextjs"
+      "url": string
+    }
+    "Postgres1": {
+      "database": string
+      "host": string
+      "password": string
+      "port": number
+      "type": "sst.aws.Postgres"
+      "username": string
+    }
+    "SeedLambda": {
+      "name": string
+      "type": "sst.aws.Function"
+    }
+    "Vpc": {
+      "bastion": string
+      "type": "sst.aws.Vpc"
+    }
   }
 }

--- a/packages/api/.prettierignore
+++ b/packages/api/.prettierignore
@@ -1,0 +1,1 @@
+sst-env.d.ts

--- a/packages/api/sst-env.d.ts
+++ b/packages/api/sst-env.d.ts
@@ -2,58 +2,46 @@
 /* tslint:disable */
 /* eslint-disable */
 /* deno-fmt-ignore-file */
-import "sst";
-export {};
+import "sst"
+export {}
 declare module "sst" {
   export interface Resource {
-    Bucket1: {
-      name: string;
-      type: "sst.aws.Bucket";
-    };
-    Email1: {
-      configSet: string;
-      sender: string;
-      type: "sst.aws.Email";
-    };
-    MigrationLambda: {
-      name: string;
-      type: "sst.aws.Function";
-    };
-    MyRouter: {
-      type: "sst.aws.Router";
-      url: string;
-    };
-    MyWeb: {
-      type: "sst.aws.Nextjs";
-      url: string;
-    };
-    Postgres: {
-      database: string;
-      host: string;
-      password: string;
-      port: number;
-      type: "sst.aws.Postgres";
-      username: string;
-    };
-    Postgres1: {
-      database: string;
-      host: string;
-      password: string;
-      port: number;
-      type: "sst.aws.Postgres";
-      username: string;
-    };
-    SeedLambda: {
-      name: string;
-      type: "sst.aws.Function";
-    };
-    Vpc: {
-      bastion: string;
-      type: "sst.aws.Vpc";
-    };
-    Vpc1: {
-      bastion: string;
-      type: "sst.aws.Vpc";
-    };
+    "Bucket1": {
+      "name": string
+      "type": "sst.aws.Bucket"
+    }
+    "Email1": {
+      "configSet": string
+      "sender": string
+      "type": "sst.aws.Email"
+    }
+    "MigrationLambda": {
+      "name": string
+      "type": "sst.aws.Function"
+    }
+    "MyRouter": {
+      "type": "sst.aws.Router"
+      "url": string
+    }
+    "MyWeb": {
+      "type": "sst.aws.Nextjs"
+      "url": string
+    }
+    "Postgres1": {
+      "database": string
+      "host": string
+      "password": string
+      "port": number
+      "type": "sst.aws.Postgres"
+      "username": string
+    }
+    "SeedLambda": {
+      "name": string
+      "type": "sst.aws.Function"
+    }
+    "Vpc": {
+      "bastion": string
+      "type": "sst.aws.Vpc"
+    }
   }
 }

--- a/packages/auth/.prettierignore
+++ b/packages/auth/.prettierignore
@@ -1,0 +1,1 @@
+sst-env.d.ts

--- a/packages/auth/sst-env.d.ts
+++ b/packages/auth/sst-env.d.ts
@@ -2,58 +2,46 @@
 /* tslint:disable */
 /* eslint-disable */
 /* deno-fmt-ignore-file */
-import "sst";
-export {};
+import "sst"
+export {}
 declare module "sst" {
   export interface Resource {
-    Bucket1: {
-      name: string;
-      type: "sst.aws.Bucket";
-    };
-    Email1: {
-      configSet: string;
-      sender: string;
-      type: "sst.aws.Email";
-    };
-    MigrationLambda: {
-      name: string;
-      type: "sst.aws.Function";
-    };
-    MyRouter: {
-      type: "sst.aws.Router";
-      url: string;
-    };
-    MyWeb: {
-      type: "sst.aws.Nextjs";
-      url: string;
-    };
-    Postgres: {
-      database: string;
-      host: string;
-      password: string;
-      port: number;
-      type: "sst.aws.Postgres";
-      username: string;
-    };
-    Postgres1: {
-      database: string;
-      host: string;
-      password: string;
-      port: number;
-      type: "sst.aws.Postgres";
-      username: string;
-    };
-    SeedLambda: {
-      name: string;
-      type: "sst.aws.Function";
-    };
-    Vpc: {
-      bastion: string;
-      type: "sst.aws.Vpc";
-    };
-    Vpc1: {
-      bastion: string;
-      type: "sst.aws.Vpc";
-    };
+    "Bucket1": {
+      "name": string
+      "type": "sst.aws.Bucket"
+    }
+    "Email1": {
+      "configSet": string
+      "sender": string
+      "type": "sst.aws.Email"
+    }
+    "MigrationLambda": {
+      "name": string
+      "type": "sst.aws.Function"
+    }
+    "MyRouter": {
+      "type": "sst.aws.Router"
+      "url": string
+    }
+    "MyWeb": {
+      "type": "sst.aws.Nextjs"
+      "url": string
+    }
+    "Postgres1": {
+      "database": string
+      "host": string
+      "password": string
+      "port": number
+      "type": "sst.aws.Postgres"
+      "username": string
+    }
+    "SeedLambda": {
+      "name": string
+      "type": "sst.aws.Function"
+    }
+    "Vpc": {
+      "bastion": string
+      "type": "sst.aws.Vpc"
+    }
   }
 }

--- a/packages/db/.prettierignore
+++ b/packages/db/.prettierignore
@@ -1,0 +1,1 @@
+sst-env.d.ts

--- a/packages/db/sst-env.d.ts
+++ b/packages/db/sst-env.d.ts
@@ -2,58 +2,46 @@
 /* tslint:disable */
 /* eslint-disable */
 /* deno-fmt-ignore-file */
-import "sst";
-export {};
+import "sst"
+export {}
 declare module "sst" {
   export interface Resource {
-    Bucket1: {
-      name: string;
-      type: "sst.aws.Bucket";
-    };
-    Email1: {
-      configSet: string;
-      sender: string;
-      type: "sst.aws.Email";
-    };
-    MigrationLambda: {
-      name: string;
-      type: "sst.aws.Function";
-    };
-    MyRouter: {
-      type: "sst.aws.Router";
-      url: string;
-    };
-    MyWeb: {
-      type: "sst.aws.Nextjs";
-      url: string;
-    };
-    Postgres: {
-      database: string;
-      host: string;
-      password: string;
-      port: number;
-      type: "sst.aws.Postgres";
-      username: string;
-    };
-    Postgres1: {
-      database: string;
-      host: string;
-      password: string;
-      port: number;
-      type: "sst.aws.Postgres";
-      username: string;
-    };
-    SeedLambda: {
-      name: string;
-      type: "sst.aws.Function";
-    };
-    Vpc: {
-      bastion: string;
-      type: "sst.aws.Vpc";
-    };
-    Vpc1: {
-      bastion: string;
-      type: "sst.aws.Vpc";
-    };
+    "Bucket1": {
+      "name": string
+      "type": "sst.aws.Bucket"
+    }
+    "Email1": {
+      "configSet": string
+      "sender": string
+      "type": "sst.aws.Email"
+    }
+    "MigrationLambda": {
+      "name": string
+      "type": "sst.aws.Function"
+    }
+    "MyRouter": {
+      "type": "sst.aws.Router"
+      "url": string
+    }
+    "MyWeb": {
+      "type": "sst.aws.Nextjs"
+      "url": string
+    }
+    "Postgres1": {
+      "database": string
+      "host": string
+      "password": string
+      "port": number
+      "type": "sst.aws.Postgres"
+      "username": string
+    }
+    "SeedLambda": {
+      "name": string
+      "type": "sst.aws.Function"
+    }
+    "Vpc": {
+      "bastion": string
+      "type": "sst.aws.Vpc"
+    }
   }
 }

--- a/packages/ui/.prettierignore
+++ b/packages/ui/.prettierignore
@@ -1,0 +1,1 @@
+sst-env.d.ts

--- a/packages/ui/sst-env.d.ts
+++ b/packages/ui/sst-env.d.ts
@@ -2,58 +2,46 @@
 /* tslint:disable */
 /* eslint-disable */
 /* deno-fmt-ignore-file */
-import "sst";
-export {};
+import "sst"
+export {}
 declare module "sst" {
   export interface Resource {
-    Bucket1: {
-      name: string;
-      type: "sst.aws.Bucket";
-    };
-    Email1: {
-      configSet: string;
-      sender: string;
-      type: "sst.aws.Email";
-    };
-    MigrationLambda: {
-      name: string;
-      type: "sst.aws.Function";
-    };
-    MyRouter: {
-      type: "sst.aws.Router";
-      url: string;
-    };
-    MyWeb: {
-      type: "sst.aws.Nextjs";
-      url: string;
-    };
-    Postgres: {
-      database: string;
-      host: string;
-      password: string;
-      port: number;
-      type: "sst.aws.Postgres";
-      username: string;
-    };
-    Postgres1: {
-      database: string;
-      host: string;
-      password: string;
-      port: number;
-      type: "sst.aws.Postgres";
-      username: string;
-    };
-    SeedLambda: {
-      name: string;
-      type: "sst.aws.Function";
-    };
-    Vpc: {
-      bastion: string;
-      type: "sst.aws.Vpc";
-    };
-    Vpc1: {
-      bastion: string;
-      type: "sst.aws.Vpc";
-    };
+    "Bucket1": {
+      "name": string
+      "type": "sst.aws.Bucket"
+    }
+    "Email1": {
+      "configSet": string
+      "sender": string
+      "type": "sst.aws.Email"
+    }
+    "MigrationLambda": {
+      "name": string
+      "type": "sst.aws.Function"
+    }
+    "MyRouter": {
+      "type": "sst.aws.Router"
+      "url": string
+    }
+    "MyWeb": {
+      "type": "sst.aws.Nextjs"
+      "url": string
+    }
+    "Postgres1": {
+      "database": string
+      "host": string
+      "password": string
+      "port": number
+      "type": "sst.aws.Postgres"
+      "username": string
+    }
+    "SeedLambda": {
+      "name": string
+      "type": "sst.aws.Function"
+    }
+    "Vpc": {
+      "bastion": string
+      "type": "sst.aws.Vpc"
+    }
   }
 }

--- a/packages/validators/.prettierignore
+++ b/packages/validators/.prettierignore
@@ -1,0 +1,1 @@
+sst-env.d.ts

--- a/packages/validators/sst-env.d.ts
+++ b/packages/validators/sst-env.d.ts
@@ -2,58 +2,46 @@
 /* tslint:disable */
 /* eslint-disable */
 /* deno-fmt-ignore-file */
-import "sst";
-export {};
+import "sst"
+export {}
 declare module "sst" {
   export interface Resource {
-    Bucket1: {
-      name: string;
-      type: "sst.aws.Bucket";
-    };
-    Email1: {
-      configSet: string;
-      sender: string;
-      type: "sst.aws.Email";
-    };
-    MigrationLambda: {
-      name: string;
-      type: "sst.aws.Function";
-    };
-    MyRouter: {
-      type: "sst.aws.Router";
-      url: string;
-    };
-    MyWeb: {
-      type: "sst.aws.Nextjs";
-      url: string;
-    };
-    Postgres: {
-      database: string;
-      host: string;
-      password: string;
-      port: number;
-      type: "sst.aws.Postgres";
-      username: string;
-    };
-    Postgres1: {
-      database: string;
-      host: string;
-      password: string;
-      port: number;
-      type: "sst.aws.Postgres";
-      username: string;
-    };
-    SeedLambda: {
-      name: string;
-      type: "sst.aws.Function";
-    };
-    Vpc: {
-      bastion: string;
-      type: "sst.aws.Vpc";
-    };
-    Vpc1: {
-      bastion: string;
-      type: "sst.aws.Vpc";
-    };
+    "Bucket1": {
+      "name": string
+      "type": "sst.aws.Bucket"
+    }
+    "Email1": {
+      "configSet": string
+      "sender": string
+      "type": "sst.aws.Email"
+    }
+    "MigrationLambda": {
+      "name": string
+      "type": "sst.aws.Function"
+    }
+    "MyRouter": {
+      "type": "sst.aws.Router"
+      "url": string
+    }
+    "MyWeb": {
+      "type": "sst.aws.Nextjs"
+      "url": string
+    }
+    "Postgres1": {
+      "database": string
+      "host": string
+      "password": string
+      "port": number
+      "type": "sst.aws.Postgres"
+      "username": string
+    }
+    "SeedLambda": {
+      "name": string
+      "type": "sst.aws.Function"
+    }
+    "Vpc": {
+      "bastion": string
+      "type": "sst.aws.Vpc"
+    }
   }
 }

--- a/sst-env.d.ts
+++ b/sst-env.d.ts
@@ -27,14 +27,6 @@ declare module "sst" {
       "type": "sst.aws.Nextjs"
       "url": string
     }
-    "Postgres": {
-      "database": string
-      "host": string
-      "password": string
-      "port": number
-      "type": "sst.aws.Postgres"
-      "username": string
-    }
     "Postgres1": {
       "database": string
       "host": string
@@ -48,10 +40,6 @@ declare module "sst" {
       "type": "sst.aws.Function"
     }
     "Vpc": {
-      "bastion": string
-      "type": "sst.aws.Vpc"
-    }
-    "Vpc1": {
       "bastion": string
       "type": "sst.aws.Vpc"
     }

--- a/tooling/eslint/sst-env.d.ts
+++ b/tooling/eslint/sst-env.d.ts
@@ -27,14 +27,6 @@ declare module "sst" {
       "type": "sst.aws.Nextjs"
       "url": string
     }
-    "Postgres": {
-      "database": string
-      "host": string
-      "password": string
-      "port": number
-      "type": "sst.aws.Postgres"
-      "username": string
-    }
     "Postgres1": {
       "database": string
       "host": string
@@ -48,10 +40,6 @@ declare module "sst" {
       "type": "sst.aws.Function"
     }
     "Vpc": {
-      "bastion": string
-      "type": "sst.aws.Vpc"
-    }
-    "Vpc1": {
       "bastion": string
       "type": "sst.aws.Vpc"
     }

--- a/tooling/typescript/sst-env.d.ts
+++ b/tooling/typescript/sst-env.d.ts
@@ -27,14 +27,6 @@ declare module "sst" {
       "type": "sst.aws.Nextjs"
       "url": string
     }
-    "Postgres": {
-      "database": string
-      "host": string
-      "password": string
-      "port": number
-      "type": "sst.aws.Postgres"
-      "username": string
-    }
     "Postgres1": {
       "database": string
       "host": string
@@ -48,10 +40,6 @@ declare module "sst" {
       "type": "sst.aws.Function"
     }
     "Vpc": {
-      "bastion": string
-      "type": "sst.aws.Vpc"
-    }
-    "Vpc1": {
       "bastion": string
       "type": "sst.aws.Vpc"
     }


### PR DESCRIPTION
sst-env.d.ts should stop being falsly flagged as changed because the pre-commit hook formats the file.
.prettierignore files in each package should now correctly ignore the files during formatting.