### PR TITLE
production database migration automation

### DIFF
--- a/infra/storage.ts
+++ b/infra/storage.ts
@@ -1,5 +1,3 @@
-import { readdir } from "fs/promises";
-
 export const bucket = new sst.aws.Bucket("Bucket1", {
   access: "cloudfront",
 });

--- a/infra/storage.ts
+++ b/infra/storage.ts
@@ -66,8 +66,9 @@ export const seedLambda = new sst.aws.Function(
 if (!$dev) {
   new aws.lambda.Invocation("MigratorInvocation", {
     functionName: migrationLambda.name,
-    lifecycleScope: "CRUD",
-
+    triggers: {
+      now: new Date().toISOString(),
+    },
     input: JSON.stringify({
       now: new Date().toISOString(),
     }),

--- a/infra/storage.ts
+++ b/infra/storage.ts
@@ -66,12 +66,14 @@ export const seedLambda = new sst.aws.Function(
 if (!$dev) {
   new aws.lambda.Invocation("MigratorInvocation", {
     functionName: migrationLambda.name,
+    lifecycleScope: "CRUD",
+
     input: JSON.stringify({
       now: new Date().toISOString(),
     }),
   });
 
-  if ($app.stage.startsWith("pr-")) {
+  if ($app.stage.startsWith("staging")) {
     new aws.lambda.Invocation("SeedInvocation", {
       functionName: seedLambda.name,
       input: JSON.stringify({


### PR DESCRIPTION
currently, the database is not automatically being migrated in production. This is believed to be because the pulumi lambda invocation is only run on initial creation. Changing to run lambda invocations on every redeploy